### PR TITLE
Fix block break event not firing on multiplayer

### DIFF
--- a/src/main/java/mcp/mobius/waila/Waila.java
+++ b/src/main/java/mcp/mobius/waila/Waila.java
@@ -15,6 +15,7 @@ import mcp.mobius.waila.api.impl.WailaRegistrar;
 import mcp.mobius.waila.api.impl.config.PluginConfig;
 import mcp.mobius.waila.api.impl.config.WailaConfig;
 import mcp.mobius.waila.command.CommandDumpHandlers;
+import mcp.mobius.waila.network.MessageBlockBreak;
 import mcp.mobius.waila.network.MessageReceiveData;
 import mcp.mobius.waila.network.MessageRequestEntity;
 import mcp.mobius.waila.network.MessageRequestTile;
@@ -63,6 +64,7 @@ public class Waila {
 		NETWORK.registerMessage(1, MessageServerPing.class, MessageServerPing::write, MessageServerPing::read, MessageServerPing.Handler::onMessage, Optional.of(NetworkDirection.PLAY_TO_CLIENT));
 		NETWORK.registerMessage(2, MessageRequestEntity.class, MessageRequestEntity::write, MessageRequestEntity::read, MessageRequestEntity.Handler::onMessage, Optional.of(NetworkDirection.PLAY_TO_SERVER));
 		NETWORK.registerMessage(3, MessageRequestTile.class, MessageRequestTile::write, MessageRequestTile::read, MessageRequestTile.Handler::onMessage, Optional.of(NetworkDirection.PLAY_TO_SERVER));
+		NETWORK.registerMessage(4, MessageBlockBreak.class, MessageBlockBreak::write, MessageBlockBreak::read, MessageBlockBreak.Handler::onMessage, Optional.of(NetworkDirection.PLAY_TO_CLIENT));
 	}
 
 	@SubscribeEvent

--- a/src/main/java/mcp/mobius/waila/network/MessageBlockBreak.java
+++ b/src/main/java/mcp/mobius/waila/network/MessageBlockBreak.java
@@ -1,0 +1,31 @@
+package mcp.mobius.waila.network;
+
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+import snownee.jade.client.ClientHandler;
+
+import java.util.function.Supplier;
+
+public class MessageBlockBreak {
+
+	public MessageBlockBreak() {
+	}
+
+	public static MessageBlockBreak read(PacketBuffer buffer) {
+		return new MessageBlockBreak();
+	}
+
+	public static void write(MessageBlockBreak message, PacketBuffer buffer) {
+	}
+
+	public static class Handler {
+		public static void onMessage(MessageBlockBreak message, Supplier<NetworkEvent.Context> context) {
+			context.get().enqueueWork(() -> {
+				ClientHandler.setProgressAlpha(1);
+				ClientHandler.setSavedProgress(1);
+			});
+			context.get().setPacketHandled(true);
+		}
+	}
+
+}

--- a/src/main/java/snownee/jade/Jade.java
+++ b/src/main/java/snownee/jade/Jade.java
@@ -2,6 +2,14 @@ package snownee.jade;
 
 import java.text.DecimalFormat;
 
+import mcp.mobius.waila.Waila;
+import mcp.mobius.waila.network.MessageBlockBreak;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.world.IWorld;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.network.NetworkDirection;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraftforge.fml.ExtensionPoint;
@@ -27,5 +35,18 @@ public class Jade {
 
 	private void init(FMLCommonSetupEvent event) {
 		JadeCommonConfig.refresh();
+	}
+
+	@Mod.EventBusSubscriber
+	public static class JadeBlockEvent {
+
+		@SubscribeEvent
+		public static void breakBlock(BlockEvent.BreakEvent event) {
+			IWorld world = event.getWorld();
+			boolean isRemote = world.isRemote();
+			if (!isRemote) {
+				Waila.NETWORK.sendTo(new MessageBlockBreak(), ((ServerPlayerEntity) event.getPlayer()).connection.netManager, NetworkDirection.PLAY_TO_CLIENT);
+			}
+		}
 	}
 }

--- a/src/main/java/snownee/jade/client/ClientHandler.java
+++ b/src/main/java/snownee/jade/client/ClientHandler.java
@@ -13,8 +13,6 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.event.world.BlockEvent.BreakEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import snownee.jade.JadePlugin;
@@ -65,9 +63,12 @@ public final class ClientHandler {
 		return (color & 0xFFFFFF) | alphaChannel << 24;
 	}
 
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public static void breakBlock(BreakEvent event) {
-		progressAlpha = 1;
+	public static void setProgressAlpha(float alpha) {
+		progressAlpha = alpha;
+	}
+
+	public static void setSavedProgress(float progress) {
+		savedProgress = progress;
 	}
 
 }


### PR DESCRIPTION
This merge attempts to resolve an issue with the block event only firing when on singleplayer/as a LAN host. From my testing, the actual block break event is fired on the logical thread as opposed to the render thread, which leads to `progressAlpha` not being set to `1` during block breaks in multiplayer.

This has been mitigated by creating a new empty message to have the client handler update the progress and send that message to the player that broke the block. This method I did was probably crude and hacky, I assumed in terms of networking this would be the simplest resolution. I didn't opt to make a port to 1.17 before the code itself has been solidified by you, but feel free to make any edits as you wish. Cheers! 