### PR TITLE
fix: readme now contains updated gradledependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repositories {
 dependencies {
     // Visit https://www.curseforge.com/minecraft/mc-mods/jade/files/all
     // to get the latest version's jade_id
-    implementation fg.deobf("curse.maven:jade-324717:${jade_id}")
+    modImplementation "curse.maven:jade-324717:${jade_id}"
 }
 ```
 


### PR DESCRIPTION
The documentation discussing adding jade as a dependancy for `fabric 1.19` was out of date.