### PR TITLE
Fix maven publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ run
 /logs
 *.log
 /site/
+/mcmodsrepo

--- a/build.gradle
+++ b/build.gradle
@@ -87,8 +87,15 @@ task apiJar(type: Jar) {
     from sourceSets.main.output
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
 artifacts {
     archives apiJar
+    archives sourcesJar
 }
 
 repositories {
@@ -138,7 +145,12 @@ jar.finalizedBy('reobfJar')
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            groupId = project.group
+            artifactId = project.archivesBaseName
+            version = project.version
             artifact jar
+            artifact apiJar
+            artifact sourcesJar
         }
     }
     repositories {


### PR DESCRIPTION
This fixes up the maven publish build steps.

After merging, you'd just need to run `gradle publish` (on each active minecraft branch) and this will create a bunch of files in the `mcmodsrepo` folder.

Upload the contents of that folder to a convenient web server, and bam, you now have a valid maven repository that you can point people at instead of CurseMaven (which can be problematic since it goes down a lot).

Bonus: it now has a separate api jar as well, so e.g:

```
    maven {
        name "Jade"
        url "https://YOUR.SERVER.URL.HERE/maven/"
        content {
            includeGroup "snownee.jade"
        }
    }
...
    compileOnly fg.deobf("snownee.jade:Jade-${project.jade_mcversion}-forge:${project.jade_version}:api")
    runtimeOnly fg.deobf("snownee.jade:Jade-${project.jade_mcversion}-forge:${project.jade_version}")
```