### PR TITLE
Fix: Horse Speed to correct value

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
@@ -32,7 +32,7 @@ public enum HorseStatsProvider implements IEntityComponentProvider {
 		double jumpStrength = horse.getCustomJump();
 		double jumpHeight = -0.1817584952 * jumpStrength * jumpStrength * jumpStrength + 3.689713992 * jumpStrength * jumpStrength + 2.128599134 * jumpStrength - 0.343930367;
 		// https://minecraft.fandom.com/wiki/Horse?so=search#Movement_speed
-		double speed = horse.getAttributeValue(Attributes.MOVEMENT_SPEED) * 43.17;
+		double speed = horse.getAttributeValue(Attributes.MOVEMENT_SPEED) * 42.16;
 		tooltip.add(Component.translatable("jade.horseStat.jump", t.info(DisplayHelper.dfCommas.format(jumpHeight))));
 		tooltip.add(Component.translatable("jade.horseStat.speed", t.info(DisplayHelper.dfCommas.format(speed))));
 	}


### PR DESCRIPTION
Horses travel slightly slower than a Player for each 0.1 internal units, updated value from 43.17 to 42.16 to reflect this.
https://minecraft.fandom.com/wiki/Horse#Movement_speed