### PR TITLE
Use 'mm:ss' format instead of just 'ss'

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/MobBreedingProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/MobBreedingProvider.java
@@ -26,7 +26,10 @@ public enum MobBreedingProvider implements IEntityComponentProvider, IServerData
 		}
 		int time = accessor.getServerData().getInt("BreedingCD");
 		if (time > 0) {
-			tooltip.add(Component.translatable(accessor.getEntity() instanceof Allay ? "jade.mobduplication.time" : "jade.mobbreeding.time", IThemeHelper.get().seconds(time)));
+			var totalSeconds = time / 20;
+			var seconds = totalSeconds % 60;
+			var minutes = totalSeconds / 60;
+			tooltip.add(Component.translatable(accessor.getEntity() instanceof Allay ? "jade.mobduplication.time" : "jade.mobbreeding.time", "%d:%02d".formatted(minutes, seconds)));
 		}
 	}
 

--- a/src/main/java/snownee/jade/addon/vanilla/MobGrowthProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/MobGrowthProvider.java
@@ -26,7 +26,10 @@ public enum MobGrowthProvider implements IEntityComponentProvider, IServerDataPr
 		}
 		int time = accessor.getServerData().getInt("GrowingTime");
 		if (time > 0) {
-			tooltip.add(Component.translatable("jade.mobgrowth.time", IThemeHelper.get().seconds(time)));
+			var totalSeconds = time / 20;
+			var seconds = totalSeconds % 60;
+			var minutes = totalSeconds / 60;
+			tooltip.add(Component.translatable("jade.mobgrowth.time", "%d:%02d".formatted(minutes, seconds)));
 		}
 	}
 


### PR DESCRIPTION
Not sure how many other vanilla Jade addons use seconds instead of `mm:ss` format, but these are the 2 I've found.
If there's a better way to do what I'm doing, feel free to make edits.
I also thought about making a config option for this, but I can't be bothered.
<img width="583" alt="Breeding CD: 4:03" src="https://github.com/Snownee/Jade/assets/69256931/3f0f52b5-d1c7-440a-9e49-5f6b04765650">
<img width="583" alt="Growing time: 18:53" src="https://github.com/Snownee/Jade/assets/69256931/d341a8a6-8eaa-4a72-b08d-4df5aa625dc0">
(Oh and if only you *knew* how long it took for me to fix every problem I had building the project just for this 😭)