### PR TITLE
Fix memory leak on client disconnect

### DIFF
--- a/src/main/java/snownee/jade/network/RequestEntityPacket.java
+++ b/src/main/java/snownee/jade/network/RequestEntityPacket.java
@@ -28,6 +28,7 @@ public class RequestEntityPacket {
 
 	public static void write(RequestEntityPacket message, FriendlyByteBuf buffer) {
 		message.accessor.toNetwork(buffer);
+		message.accessor = null;
 	}
 
 	public static class Handler {


### PR DESCRIPTION
I've been profiling All the Mods 9, a heavy modpack with 400+ mods, to try and reduce the most impactful memory leaks. I discovered that the accessor object in RequestEntityPacket transiently holds onto a reference of ClientLevel, which weighs over 300MB. This packet appears to get stuck in Minecraft's performance measuring mechanism, and so the reference gets retained. I haven't confirmed whether it gets released eventually or not, but I wanted to raise this here and hear your thoughts. I implemented a naive fix which seems to work, basically just cleaning the accessor after the packet has been written. I confirmed that currently, no packet object is reused for more than one write. Another solution may be to use a WeakReference.

![Screenshot 2024-05-14 at 01 00 20](https://github.com/Snownee/Jade/assets/2650170/5b873857-c610-4105-a708-0788f4ee7364)
