### PR TITLE
fix: ItemStorageProvider.Extension Priority

### DIFF
--- a/src/main/java/snownee/jade/addon/universal/EnergyStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/EnergyStorageProvider.java
@@ -164,7 +164,7 @@ public abstract class EnergyStorageProvider<T extends Accessor<?>> implements IC
 
 		@Override
 		public int getDefaultPriority() {
-			return TooltipPosition.BODY + 1000;
+			return TooltipPosition.TAIL;
 		}
 	}
 

--- a/src/main/java/snownee/jade/addon/universal/EnergyStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/EnergyStorageProvider.java
@@ -161,6 +161,11 @@ public abstract class EnergyStorageProvider<T extends Accessor<?>> implements IC
 		public boolean shouldRequestData(Accessor<?> accessor) {
 			return CommonProxy.hasDefaultEnergyStorage(accessor);
 		}
+
+		@Override
+		public int getDefaultPriority() {
+			return TooltipPosition.BODY + 1000;
+		}
 	}
 
 }

--- a/src/main/java/snownee/jade/addon/universal/FluidStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/FluidStorageProvider.java
@@ -165,6 +165,11 @@ public abstract class FluidStorageProvider<T extends Accessor<?>> implements ICo
 		public boolean shouldRequestData(Accessor<?> accessor) {
 			return CommonProxy.hasDefaultFluidStorage(accessor);
 		}
+
+		@Override
+		public int getDefaultPriority() {
+			return TooltipPosition.BODY + 1000;
+		}
 	}
 
 }

--- a/src/main/java/snownee/jade/addon/universal/FluidStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/FluidStorageProvider.java
@@ -168,7 +168,7 @@ public abstract class FluidStorageProvider<T extends Accessor<?>> implements ICo
 
 		@Override
 		public int getDefaultPriority() {
-			return TooltipPosition.BODY + 1000;
+			return TooltipPosition.TAIL;
 		}
 	}
 

--- a/src/main/java/snownee/jade/addon/universal/ItemStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/ItemStorageProvider.java
@@ -337,7 +337,7 @@ public abstract class ItemStorageProvider<T extends Accessor<?>> implements ICom
 
 		@Override
 		public int getDefaultPriority() {
-			return TooltipPosition.BODY + 1000;
+			return TooltipPosition.TAIL;
 		}
 	}
 

--- a/src/main/java/snownee/jade/addon/universal/ItemStorageProvider.java
+++ b/src/main/java/snownee/jade/addon/universal/ItemStorageProvider.java
@@ -334,6 +334,11 @@ public abstract class ItemStorageProvider<T extends Accessor<?>> implements ICom
 		public boolean shouldRequestData(Accessor<?> accessor) {
 			return CommonProxy.hasDefaultItemStorage(accessor);
 		}
+
+		@Override
+		public int getDefaultPriority() {
+			return TooltipPosition.BODY + 1000;
+		}
 	}
 
 }


### PR DESCRIPTION
it seems to have been overlooked during the update, and cause other storage providers not to function properly.