### PR TITLE
fix: zombie villager provider does not work

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/ZombieVillagerProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/ZombieVillagerProvider.java
@@ -30,7 +30,7 @@ public enum ZombieVillagerProvider implements IEntityComponentProvider, StreamSe
 
 	@Override
 	public boolean shouldRequestData(EntityAccessor accessor) {
-		return ((ZombieVillager) accessor).isConverting();
+		return ((ZombieVillager) accessor.getEntity()).isConverting();
 	}
 
 	@Override


### PR DESCRIPTION
在Jade 1.21版本开始，僵尸村民的显示会失效，并且在开发环境下会直接导致游戏崩溃。具体原因就是对错误的对象进行类型转换。