### PR TITLE
[1.21 Fabric] Make hideModName cache use weak references

### DIFF
--- a/src/main/java/snownee/jade/JadeClient.java
+++ b/src/main/java/snownee/jade/JadeClient.java
@@ -81,6 +81,8 @@ public final class JadeClient {
 	public static KeyMapping showRecipes;
 	public static KeyMapping showUses;
 	private static final Cache<Item.TooltipContext, Item.TooltipContext> hideModName = CacheBuilder.newBuilder()
+			.weakKeys()
+			.weakValues()
 			.expireAfterAccess(1, TimeUnit.SECONDS)
 			.build();
 	private static boolean translationChecked;


### PR DESCRIPTION
Minimises the window where the tooltip can end up leaking large objects.

This isn't strictly necessary, but it helps when you're playing with mods that end up inflating the context by a lot by storing a world or so in it.

This is applicable for, frankly all versions this cache exists.

Another route would be making a WeakHashSet given all this is used for is whether the item should have the mod name added to its tooltip.