### PR TITLE
[1.21.5 Fabric] Make hideModName cache use weak references

### DIFF
--- a/src/main/java/snownee/jade/JadeClient.java
+++ b/src/main/java/snownee/jade/JadeClient.java
@@ -85,6 +85,8 @@ public final class JadeClient {
 	public static KeyMapping showRecipes;
 	public static KeyMapping showUses;
 	private static final Cache<Item.TooltipContext, Item.TooltipContext> hideModName = CacheBuilder.newBuilder()
+			.weakKeys()
+			.weakValues()
 			.expireAfterAccess(1, TimeUnit.SECONDS)
 			.build();
 	private static boolean translationChecked;


### PR DESCRIPTION
Minimises the window where the tooltip can end up leaking large objects.

Same as #558 for 1.21.5