### PR TITLE
Use modified attribute values for horse stats info

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
@@ -48,13 +48,13 @@ public enum HorseStatsProvider implements IEntityComponentProvider {
 			return;
 		}
 		if (horse.getAttributes().hasAttribute(Attributes.JUMP_STRENGTH)) {
-			double jumpStrength = horse.getAttributeBaseValue(Attributes.JUMP_STRENGTH);
+			double jumpStrength = horse.getAttributeValue(Attributes.JUMP_STRENGTH);
 			double jumpHeight = getJumpHeight(jumpStrength);
 			tooltip.add(switchText("jade.horseStat.jump", showMax, jumpHeight, MAX_JUMP_HEIGHT));
 		}
 		if (horse.getAttributes().hasAttribute(Attributes.MOVEMENT_SPEED)) {
 			// https://minecraft.fandom.com/wiki/Horse?so=search#Movement_speed
-			double speed = horse.getAttributeBaseValue(Attributes.MOVEMENT_SPEED) * 42.16;
+			double speed = horse.getAttributeValue(Attributes.MOVEMENT_SPEED) * 42.16;
 			tooltip.add(switchText("jade.horseStat.speed", showMax, speed, MAX_MOVEMENT_SPEED));
 		}
 	}


### PR DESCRIPTION
Changes `HorseStatsProvider#appendTooltip` to use getAttibuteValue instead. This accounts for modifiers in horse stats info, like potion effects or other modifiers added by mods (this came up because a modifier I applied to horses was not showing up in Jade)