### PR TITLE
Fixed Horse Jump height

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/HorseStatsProvider.java
@@ -31,8 +31,7 @@ public class HorseStatsProvider implements IEntityComponentProvider {
 	}
 
 	private static double getJumpHeight(double jumpStrength) {
-		return -0.1817584952 * jumpStrength * jumpStrength * jumpStrength + 3.689713992 * jumpStrength * jumpStrength +
-				2.128599134 * jumpStrength - 0.343930367;
+		return 4.53680079 * jumpStrength * jumpStrength + 1.61431730 * jumpStrength - -0.22656224;
 	}
 
 	@Override


### PR DESCRIPTION
Re-derived the formula because it changed at some point; Horses can jump higher than they used to be able to. The original equation didn't need to be cubic either, so it's parabolic now.

To get my data, I used a Scarpet script to sweep the entire strength range from 0.4 to 1.0 in increments of 0.0001. Once I had that data, I used a Python script to perform the regression, and after testing a few equations I found that parabolic matched nearly perfect, which makes sense for gravity.

[Here](https://gist.github.com/Micalobia/f61c902d0c76d582865e8470b0fc4757) is my gist with both the Scarpet and Python scripts, as well as the generated data.

For history's sake, my original derivation (with data included) is [here](https://www.desmos.com/calculator/3ljbjzmn7z), which is different to the formula you pulled from the wiki at the time. It was on the wiki at some point (or at least one of my formulas was, I've done this a few times manually). As of right now there isn't a formula on the wiki at all.

This data also shows that the max and min height on Java Edition reflect the Bedrock values, instead of being slightly lower as the wiki suggests.