### PR TITLE
[1.21-fabric] disable blend and depth test after rendering overlay is done

### DIFF
--- a/src/main/java/snownee/jade/overlay/OverlayRenderer.java
+++ b/src/main/java/snownee/jade/overlay/OverlayRenderer.java
@@ -210,16 +210,13 @@ public class OverlayRenderer {
 			callback.afterRender(root, rect, guiGraphics, ObjectDataCenter.get());
 		});
 
-		RenderSystem.enableBlend();
-		RenderSystem.enableDepthTest();
+		RenderSystem.disableBlend();
+		RenderSystem.disableDepthTest();
 		matrixStack.popPose();
 
 		if (Jade.CONFIG.get().getGeneral().shouldEnableTextToSpeech()) {
 			WailaTickHandler.narrate(root.getTooltip(), true);
 		}
-
-		RenderSystem.disableBlend();
-		RenderSystem.disableDepthTest();
 
 		shown = true;
 	}

--- a/src/main/java/snownee/jade/overlay/OverlayRenderer.java
+++ b/src/main/java/snownee/jade/overlay/OverlayRenderer.java
@@ -218,6 +218,9 @@ public class OverlayRenderer {
 			WailaTickHandler.narrate(root.getTooltip(), true);
 		}
 
+		RenderSystem.disableBlend();
+		RenderSystem.disableDepthTest();
+
 		shown = true;
 	}
 


### PR DESCRIPTION
in the `OverlayRenderer.renderOverlay` function it enables blend by calling `RenderSystem.enableBlend()` and depth test by calling `RenderSystem.enableDepthTest()` but these states need to be reset to their original before returning, not doing so results in blur effect on GUIs being broken when disabling the "hide from GUIs" option in mod settings