### PR TITLE
Fix #704, #734

### DIFF
--- a/src/main/java/snownee/jade/addon/vanilla/AnimalOwnerProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/AnimalOwnerProvider.java
@@ -62,8 +62,7 @@ public class AnimalOwnerProvider implements StreamServerDataProvider<EntityAcces
 		if (!(entity instanceof OwnableEntity)) return false;
 		UUID ownerUUID = getOwnerUUID(entity);
 		if (ownerUUID == null) return true;
-		if (!PlayerNameLookup.isFetched(ownerUUID)) return false;
-		return ClientProxy.lookupPlayerName(ownerUUID) == null;
+		return ClientProxy.shouldFetchFromServer(ownerUUID);
 	}
 
 	@Override

--- a/src/main/java/snownee/jade/util/ClientProxy.java
+++ b/src/main/java/snownee/jade/util/ClientProxy.java
@@ -281,6 +281,11 @@ public final class ClientProxy implements ClientModInitializer {
 		ClientPlayNetworking.send(payload);
 	}
 
+	public static boolean shouldFetchFromServer(@Nullable UUID uuid) {
+		String name = lookupPlayerName(uuid);
+		return name == null || name.equals(PlayerNameLookup.DUMMY_NAME);
+	}
+
 	@Nullable
 	public static String lookupPlayerName(@Nullable UUID uuid) {
 		return PlayerNameLookup.get(uuid, Minecraft.getInstance().services());

--- a/src/main/java/snownee/jade/util/PlayerNameLookup.java
+++ b/src/main/java/snownee/jade/util/PlayerNameLookup.java
@@ -7,15 +7,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.mojang.authlib.GameProfile;
-
 import net.minecraft.server.Services;
+import net.minecraft.server.players.NameAndId;
 import net.minecraft.util.Util;
 
 public class PlayerNameLookup {
+
+	public static final String DUMMY_NAME = "???";
+
 	private static final Set<UUID> FETCHING = ConcurrentHashMap.newKeySet();
 	private static final ConcurrentHashMap<UUID, String> FETCHED = new ConcurrentHashMap<>();
-	private static final GameProfile DUMMY_PROFILE = new GameProfile(UUID.randomUUID(), "???");
 
 	public static boolean isFetching(UUID uuid) {
 		return FETCHING.contains(uuid);
@@ -33,15 +34,21 @@ public class PlayerNameLookup {
 		if (FETCHED.containsKey(uuid)) {
 			return FETCHED.get(uuid);
 		}
+		String name = services.nameToIdCache().get(uuid).map(NameAndId::name).orElse(null);
+		if (name != null) {
+			FETCHED.put(uuid, name);
+			return name;
+		}
 		if (!FETCHING.add(uuid)) {
 			return null;
 		}
 		CompletableFuture.runAsync(
-				() -> {
-					GameProfile profile = services.profileResolver().fetchById(uuid).orElse(DUMMY_PROFILE);
-					FETCHED.put(uuid, profile.name());
-					FETCHING.remove(uuid);
-				}, Util.backgroundExecutor()
+				() -> services.profileResolver().fetchById(uuid).ifPresentOrElse(
+						profile -> {
+							FETCHED.put(uuid, profile.name());
+							FETCHING.remove(uuid);
+						}, () -> FETCHED.put(uuid, DUMMY_NAME)
+				), Util.backgroundExecutor()
 		);
 		return null;
 	}


### PR DESCRIPTION
Previously, the client put a dummy name when fails to fetch it from mojang server, but not try to get it from the server.
This pr make the client request the data from the server when the name is dummy, and [let the server also lookup from the local cache](https://github.com/LeavesMC/Leaves/blob/master/leaves-server/src/main/java/org/leavesmc/leaves/protocol/jade/provider/entity/AnimalOwnerProvider.java#L56). So the offline condition will be correctly handled.


<img width="425" height="651" alt="image" src="https://github.com/user-attachments/assets/165be355-42c3-432e-b6cc-f8b6ca1b015a" />