### PR TITLE
Fix picked block not using neoforge extension

### DIFF
--- a/src/main/java/snownee/jade/util/CommonProxy.java
+++ b/src/main/java/snownee/jade/util/CommonProxy.java
@@ -361,7 +361,7 @@ public final class CommonProxy {
 	}
 
 	public static ItemStack getBlockPickedResult(BlockState state, Player player, BlockHitResult hitResult) {
-		return state.getCloneItemStack(player.level(), hitResult.getBlockPos(), true);
+		return state.getCloneItemStack(hitResult.getBlockPos(), player.level(), true, player);
 	}
 
 	public static ItemStack getEntityPickedResult(Entity entity, Player player, EntityHitResult hitResult) {


### PR DESCRIPTION
Hello, I wanted to have the tooltip show the picked block rather than the block itself.
I noticed that Jade was using the `getCloneItemStack` in the base game, but my mod needs Jade to use the neoforge extension so it can determine which part of the block the player is looking at. Hopefully this change is okay?

Current (unexpected icon, name and mod name)
<img width="3840" height="2161" alt="2026-04-09_20 52 08" src="https://github.com/user-attachments/assets/4d4abe96-f092-4ce0-a57b-4f1628e066ff" />

With this PR (expected icon, but unexpected name and mod name)
<img width="3840" height="2161" alt="2026-04-09_20 53 44" src="https://github.com/user-attachments/assets/6f91b813-08b3-471b-a5c1-bdf2b827f284" />

As a side note, I noticed that I needed to implement a [Jade plugin](https://github.com/breakinblocks/Plonk/blob/a75ef85d9911eb30cd14f6505ae6f907a2035a3b/projects/minecraft/latest/neo/src/main/java/com/breakinblocks/plonk/common/compat/jade/PlonkJadePlugin.java#L14) to get the icon, name, and mod name to be the picked block. Is this the expected behaviour? I noticed that in `TargetOperationRepositoryImpl.shouldPick` it will return `false` if there's no built in entry, meaning [`ObjectNameProvider`](https://github.com/Snownee/Jade/blob/0cb8dab6be5d838fb043a118a2fb88f503363062/src/main/java/snownee/jade/addon/core/ObjectNameProvider.java#L105) and [`ModNameProvider`](https://github.com/Snownee/Jade/blob/0cb8dab6be5d838fb043a118a2fb88f503363062/src/main/java/snownee/jade/addon/core/ModNameProvider.java#L35) will not use the picked block's name and mod name respectively. Let me know if this is intended or if I should open an issue or add a change for that in this PR too.
<img width="3840" height="2161" alt="2026-04-09_21 47 31" src="https://github.com/user-attachments/assets/ddf37e71-0348-4ab5-a3d2-e1642b9b0df8" />
