### PR TITLE
Provide packet context for execution (fix #748)

### DIFF
--- a/src/main/java/snownee/jade/network/ClientPayloadContext.java
+++ b/src/main/java/snownee/jade/network/ClientPayloadContext.java
@@ -1,5 +1,12 @@
 package snownee.jade.network;
 
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
+import net.minecraft.client.Minecraft;
+
 public interface ClientPayloadContext {
+	static ClientPayloadContext of(Minecraft client) {
+		return client.player != null ? runnable -> client.execute(() -> PacketContext.runWithContext(client.player, runnable)) : client::execute;
+	}
+
 	void execute(Runnable runnable);
 }

--- a/src/main/java/snownee/jade/network/ServerPayloadContext.java
+++ b/src/main/java/snownee/jade/network/ServerPayloadContext.java
@@ -1,12 +1,13 @@
 package snownee.jade.network;
 
+import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
 
 public interface ServerPayloadContext {
 	default void execute(Runnable runnable) {
-		player().level().getServer().execute(runnable);
+		player().level().getServer().execute(() -> PacketContext.runWithContext(this.player(), runnable));
 	}
 
 	default void sendPacket(CustomPacketPayload payload) {

--- a/src/main/java/snownee/jade/util/ClientProxy.java
+++ b/src/main/java/snownee/jade/util/ClientProxy.java
@@ -89,6 +89,7 @@ import snownee.jade.impl.WailaClientRegistration;
 import snownee.jade.impl.ui.FluidStackElement;
 import snownee.jade.mixin.KeyAccess;
 import snownee.jade.network.ClientHandshakePacket;
+import snownee.jade.network.ClientPayloadContext;
 import snownee.jade.network.ReceiveDataPacket;
 import snownee.jade.network.ServerHandshakePacket;
 import snownee.jade.network.ShowOverlayPacket;
@@ -324,15 +325,15 @@ public final class ClientProxy implements ClientModInitializer {
 
 		ClientPlayNetworking.registerGlobalReceiver(
 				ReceiveDataPacket.TYPE, (payload, context) -> {
-					ReceiveDataPacket.handle(payload, context.client()::execute);
+					ReceiveDataPacket.handle(payload, ClientPayloadContext.of(context.client()));
 				});
 		ClientPlayNetworking.registerGlobalReceiver(
 				ServerHandshakePacket.TYPE, (payload, context) -> {
-					ServerHandshakePacket.handle(payload, context.client()::execute);
+					ServerHandshakePacket.handle(payload, ClientPayloadContext.of(context.client()));
 				});
 		ClientPlayNetworking.registerGlobalReceiver(
 				ShowOverlayPacket.TYPE, (payload, context) -> {
-					ShowOverlayPacket.handle(payload, context.client()::execute);
+					ShowOverlayPacket.handle(payload, ClientPayloadContext.of(context.client()));
 				});
 
 		//noinspection ConstantValue


### PR DESCRIPTION
Makes Jade's execute methods setup the packet context, making it compatible with any mod depending on Fabric API's PacketContext being setup within the stream codecs. Fixes #748 / Polymer compatibility