### PR TITLE
add some context to Getting Started docs

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -1,6 +1,10 @@
 # Getting Started
 
+This is a guide for adding Jade support to another mod.
+
 ## Setup
+
+To add Jade as a dependency for your mod:
 
 === "Fabric"
 


### PR DESCRIPTION
When I clicked on "developer documentation" I was looking for instructions on how to get Jade itself to build and run. I figured this page should be a bit more explicit about what it is used for.