### PR TITLE
Add custom breaking progress provider API

### DIFF
--- a/src/main/java/snownee/jade/JadeClient.java
+++ b/src/main/java/snownee/jade/JadeClient.java
@@ -42,6 +42,7 @@ import snownee.jade.addon.universal.ItemStorageProvider;
 import snownee.jade.addon.vanilla.VanillaPlugin;
 import snownee.jade.api.Accessor;
 import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBreakingProgressProvider.BreakingProgress;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.JadeIds;
 import snownee.jade.api.JadeKeys;
@@ -345,32 +346,35 @@ public final class JadeClient {
 			progressAlpha = 0;
 			return;
 		}
-		Minecraft mc = Minecraft.getInstance();
-		MultiPlayerGameMode playerController = mc.gameMode;
-		if (playerController == null || mc.level == null || mc.player == null) {
-			return;
+		BreakingProgress breakingProgress = null;
+		for (var provider : WailaClientRegistration.instance().breakingProgressProviders.callbacks()) {
+			breakingProgress = provider.getBreakingProgress(accessor);
+			if (breakingProgress != null) {
+				break;
+			}
 		}
-		BlockPos pos = playerController.destroyBlockPos;
-		BlockState state = mc.level.getBlockState(pos);
-		if (playerController.isDestroying()) {
-			canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
+		if (breakingProgress == null) {
+			breakingProgress = getVanillaBreakingProgress();
+		}
+		boolean isBreaking = breakingProgress != null;
+		if (isBreaking) {
+			canHarvest = breakingProgress.canHarvest();
 		} else if (progressAlpha == 0) {
 			return;
 		}
+		Minecraft mc = Minecraft.getInstance();
 		Theme theme = IThemeHelper.get().theme();
 		ColorPalette colors = theme.tooltipStyle.boxProgressColors;
 		int color = canHarvest ? colors.title() : colors.failure();
 		float top = root.getY() + root.getHeight();
 		float width = root.getWidth();
-		progressAlpha += mc.getDeltaTracker().getGameTimeDeltaTicks() * (playerController.isDestroying() ? 0.1F : -0.1F);
-		if (playerController.isDestroying()) {
+		progressAlpha += mc.getDeltaTracker().getGameTimeDeltaTicks() * (isBreaking ? 0.1F : -0.1F);
+		if (isBreaking) {
 			progressAlpha = Math.min(progressAlpha, 0.6F);
-			float progress = state.getDestroyProgress(mc.player, mc.player.level(), pos);
-			if (playerController.destroyProgress + progress >= 1) {
+			if (breakingProgress.progress() >= 1) {
 				progressAlpha = savedProgress = 1;
 			} else {
-				progress = playerController.destroyProgress + mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progress;
-				savedProgress = Mth.clamp(progress, 0, 1);
+				savedProgress = Mth.clamp(breakingProgress.progress(), 0, 1);
 			}
 		} else {
 			progressAlpha = Math.max(progressAlpha, 0);
@@ -385,6 +389,27 @@ public final class JadeClient {
 		float offset3 = theme.tooltipStyle.boxProgressOffset(ScreenDirection.LEFT);
 		width += offset1 - offset3;
 		DisplayHelper.fill(graphics, offset3, top - 1 + offset0, offset3 + width * savedProgress, top + offset2, color);
+	}
+
+	@Nullable
+	private static BreakingProgress getVanillaBreakingProgress() {
+		Minecraft mc = Minecraft.getInstance();
+		MultiPlayerGameMode playerController = mc.gameMode;
+		if (playerController == null || mc.level == null || mc.player == null || !playerController.isDestroying()) {
+			return null;
+		}
+		BlockPos pos = playerController.destroyBlockPos;
+		BlockState state = mc.level.getBlockState(pos);
+		boolean canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
+		float progressPerTick = state.getDestroyProgress(mc.player, mc.player.level(), pos);
+		float progress;
+		if (playerController.destroyProgress + progressPerTick >= 1) {
+			progress = 1;
+		} else {
+			progress = playerController.destroyProgress +
+					mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progressPerTick;
+		}
+		return new BreakingProgress(progress, canHarvest);
 	}
 
 	public static MutableComponent format(String s, Object... objects) {

--- a/src/main/java/snownee/jade/api/IBreakingProgressProvider.java
+++ b/src/main/java/snownee/jade/api/IBreakingProgressProvider.java
@@ -1,0 +1,35 @@
+package snownee.jade.api;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Provides a custom source for the breaking progress bar rendered below the Jade tooltip.
+ * <p>
+ * Providers are queried on the client render thread while the tooltip is visible. Return {@code null} when the
+ * provider does not have an active operation for the current target, allowing remaining providers or Jade's
+ * vanilla block-breaking fallback to handle the bar.
+ * <p>
+ * If server-authoritative data is required, use an {@link IServerDataProvider} to append it to the accessor's server
+ * data.
+ */
+@FunctionalInterface
+public interface IBreakingProgressProvider {
+
+	/**
+	 * Returns the breaking progress to render for the current target.
+	 *
+	 * @param accessor the target currently displayed by Jade
+	 * @return the current progress, or {@code null} when this provider is not active for the target
+	 */
+	@Nullable
+	BreakingProgress getBreakingProgress(Accessor<?> accessor);
+
+	/**
+	 * The state rendered by Jade's breaking progress bar.
+	 *
+	 * @param progress   normalized progress in the range {@code [0, 1]}; values outside the range are clamped
+	 * @param canHarvest whether to use the successful-harvest color instead of the failure color
+	 */
+	record BreakingProgress(float progress, boolean canHarvest) {
+	}
+}

--- a/src/main/java/snownee/jade/api/IWailaClientRegistration.java
+++ b/src/main/java/snownee/jade/api/IWailaClientRegistration.java
@@ -96,6 +96,26 @@ public interface IWailaClientRegistration extends PlatformWailaClientRegistratio
 	 */
 	void registerEntityComponent(IComponentProvider<EntityAccessor> provider, Class<? extends Entity> entityClass);
 
+	/**
+	 * Registers a custom source for the breaking progress bar.
+	 * <p>
+	 * Providers are queried in ascending priority order. The first provider returning a non-null result handles the
+	 * bar for that frame. If no provider handles it, Jade falls back to vanilla block-breaking progress.
+	 *
+	 * @param provider the breaking progress provider
+	 */
+	default void registerBreakingProgressProvider(IBreakingProgressProvider provider) {
+		registerBreakingProgressProvider(0, provider);
+	}
+
+	/**
+	 * Registers a custom source for the breaking progress bar.
+	 *
+	 * @param priority lower values are queried first
+	 * @param provider the breaking progress provider
+	 */
+	void registerBreakingProgressProvider(int priority, IBreakingProgressProvider provider);
+
 	EmptyAccessor.Builder emptyAccessor();
 
 	BlockAccessor.Builder blockAccessor();

--- a/src/main/java/snownee/jade/impl/WailaClientRegistration.java
+++ b/src/main/java/snownee/jade/impl/WailaClientRegistration.java
@@ -47,6 +47,7 @@ import snownee.jade.api.BlockAccessor;
 import snownee.jade.api.EmptyAccessor;
 import snownee.jade.api.EntityAccessor;
 import snownee.jade.api.IComponentProvider;
+import snownee.jade.api.IBreakingProgressProvider;
 import snownee.jade.api.IToggleableProvider;
 import snownee.jade.api.IWailaClientRegistration;
 import snownee.jade.api.JadeIds;
@@ -93,6 +94,7 @@ public class WailaClientRegistration implements IWailaClientRegistration {
 	public final CallbackContainer<JadeTooltipCollectedCallback> tooltipCollectedCallback = new CallbackContainer<>();
 	public final CallbackContainer<JadeItemModNameCallback> itemModNameCallback = new CallbackContainer<>();
 	public final CallbackContainer<JadeBeforeTooltipCollectCallback> beforeTooltipCollectCallback = new CallbackContainer<>();
+	public final CallbackContainer<IBreakingProgressProvider> breakingProgressProviders = new CallbackContainer<>();
 
 	public final Map<Identifier, ConfigEntry<?>> configEntries = Maps.newHashMap();
 	public final Multimap<Identifier, Component> configCategoryOverrides = ArrayListMultimap.create();
@@ -145,6 +147,12 @@ public class WailaClientRegistration implements IWailaClientRegistration {
 	public void registerEntityComponent(IComponentProvider<EntityAccessor> provider, Class<? extends Entity> entityClass) {
 		entityComponentProviders.register(entityClass, provider);
 		tryAddConfig(provider);
+	}
+
+	@Override
+	public void registerBreakingProgressProvider(int priority, IBreakingProgressProvider provider) {
+		Objects.requireNonNull(provider);
+		breakingProgressProviders.add(priority, provider);
 	}
 
 	public List<IComponentProvider<BlockAccessor>> getBlockProviders(
@@ -350,7 +358,8 @@ public class WailaClientRegistration implements IWailaClientRegistration {
 				rayTraceCallback,
 				tooltipCollectedCallback,
 				itemModNameCallback,
-				beforeTooltipCollectCallback).forEach(CallbackContainer::sort);
+				beforeTooltipCollectCallback,
+				breakingProgressProviders).forEach(CallbackContainer::sort);
 	}
 
 	@Override

--- a/src/main/java/snownee/jade/test/ExampleBreakingProgressProvider.java
+++ b/src/main/java/snownee/jade/test/ExampleBreakingProgressProvider.java
@@ -1,0 +1,23 @@
+package snownee.jade.test;
+
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.world.level.block.Blocks;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBreakingProgressProvider;
+
+public enum ExampleBreakingProgressProvider implements IBreakingProgressProvider {
+	INSTANCE;
+
+	@Override
+	public @Nullable BreakingProgress getBreakingProgress(Accessor<?> accessor) {
+		if (!(accessor instanceof BlockAccessor blockAccessor) ||
+				blockAccessor.getBlock() != Blocks.BEDROCK ||
+				!accessor.getPlayer().isShiftKeyDown()) {
+			return null;
+		}
+		float progress = blockAccessor.getLevel().getGameTime() % 100 / 100F;
+		return new BreakingProgress(progress, true);
+	}
+}

--- a/src/main/java/snownee/jade/test/ExamplePlugin.java
+++ b/src/main/java/snownee/jade/test/ExamplePlugin.java
@@ -40,6 +40,7 @@ public class ExamplePlugin implements IWailaPlugin {
 	@Override
 	public void registerClient(IWailaClientRegistration registration) {
 		registration.registerBlockComponent(ExampleComponentProvider.INSTANCE, AbstractFurnaceBlock.class);
+		registration.registerBreakingProgressProvider(ExampleBreakingProgressProvider.INSTANCE);
 		registration.addConfig(UID_TEST_STR_CFG, "", $ -> Identifier.tryParse($) != null);
 		registration.addConfigListener(UID_TEST_STR_CFG, $ -> Jade.LOGGER.info("Changed: $: " + IWailaConfig.get().plugin().getString($)));
 		registration.addConfig(UID_TEST_FLOAT_CFG, 0F, 0F, 100F, false);


### PR DESCRIPTION
## Summary

- Add `IBreakingProgressProvider` for custom breaking progress sources.
- Add priority-based provider registration to `IWailaClientRegistration`.
- Use the first non-null custom result, then fall back to vanilla block-breaking progress.
- Reuse Jade's existing theme, configuration, colors, layout, and fade animation.
- Add a development-only example provider.

## Motivation

Jade's breaking progress bar previously read directly from `MultiPlayerGameMode`. Custom operations such as right-click item actions or multiblock transformations could not reuse the native bar without duplicating its rendering or modifying Jade internals.

This API allows mods to supply normalized progress while preserving Jade's native appearance and behavior.

## Behavior

- Providers run on the client render thread.
- Providers are queried in ascending priority order.
- Returning `null` allows the next provider or vanilla fallback to handle the bar.
- `canHarvest` selects Jade's success or failure color.
- Server-authoritative progress can use the existing server data provider system.