### PR TITLE
Validate block requests before accessing the level

### DIFF
--- a/src/main/java/snownee/jade/impl/BlockAccessorImpl.java
+++ b/src/main/java/snownee/jade/impl/BlockAccessorImpl.java
@@ -59,22 +59,23 @@ public class BlockAccessorImpl extends AccessorImpl<BlockHitResult> implements B
 	public static void handleRequest(RequestBlockPacket message, ServerPayloadContext context, Consumer<CompoundTag> responseSender) {
 		ServerPlayer player = context.player();
 		context.execute(() -> {
+			BlockPos pos = message.data().hit().getBlockPos();
+			CompoundTag tag = message.data().data();
+			tag.putInt("x", pos.getX());
+			tag.putInt("y", pos.getY());
+			tag.putInt("z", pos.getZ());
+
+			if (Jade.isOutOfReach(player, pos, player.blockInteractionRange()) || !player.level().isLoaded(pos)) {
+				responseSender.accept(tag);
+				return;
+			}
+
 			BlockAccessor accessor = message.data().unpack(player);
 			if (accessor == null) {
 				return;
 			}
 
-			BlockPos pos = accessor.getPosition();
-			CompoundTag tag = accessor.getServerData();
-			tag.putInt("x", pos.getX());
-			tag.putInt("y", pos.getY());
-			tag.putInt("z", pos.getZ());
 			tag.putString("BlockId", CommonProxy.getId(accessor.getBlock()).toString());
-
-			if (!player.level().isLoaded(pos) || Jade.isOutOfReach(player, pos, player.blockInteractionRange())) {
-				responseSender.accept(tag);
-				return;
-			}
 
 			List<IServerDataProvider<BlockAccessor>> providers = WailaCommonRegistration.instance()
 					.blockDataProvidersOf(accessor.getBlockState(), accessor.getBlockEntity(), true);


### PR DESCRIPTION
SyncData#unpack reads the requested block state before checking whether the position is loaded and within reach. A malicious request can therefore synchronously load or generate a remote chunk.

<img width="1198" height="566" alt="image" src="https://github.com/user-attachments/assets/5ee768b4-8725-46f2-ac38-a4f15f765376" />


### Fix

Validate the raw hit position before unpacking the accessor, move `unpack` after the blockpos validation check.