### PR TITLE
Use iconFile instead of the deprecated logoFile

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -9,7 +9,7 @@ displayName = "Jade"
 authors = "Snownee"
 displayURL = "https://www.curseforge.com/minecraft/mc-mods/jade"
 description = "Minecraft mod shows what you are looking at. (Hwyla fork)"
-logoFile = "icon.png"
+iconFile = "icon.png"
 credits = "TehNut, ProfMobius, kalkafox"
 
 [[mixins]]


### PR DESCRIPTION
NeoForge 26.2 logs a deprecation warning for every mod that still uses `logoFile`:

```
Mod jade uses the deprecated 'logoFile' property; change to 'bannerFile' and/or (for square icons) 'iconFile'
```

`iconFile` rather than `bannerFile` because `icon.png` is 128x128, and the warning asks for
`iconFile` specifically for square icons.

One line, no behaviour change. Only `26.2-neoforge` is touched here; `26.1-neoforge` has the same
line if you want it there too, though that depends on whether 26.1 warns about it as well.

Thanks for keeping Jade current on 26.2 — it is the only overlay on that version, which is why we
noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)