### PR TITLE
Replace breaking progress with box progress provider API

### DIFF
--- a/src/main/java/snownee/jade/JadeClient.java
+++ b/src/main/java/snownee/jade/JadeClient.java
@@ -13,19 +13,16 @@ import com.mojang.blaze3d.platform.InputConstants;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
-import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -48,22 +45,14 @@ import snownee.jade.api.JadeKeys;
 import snownee.jade.api.TraceableException;
 import snownee.jade.api.config.IWailaConfig;
 import snownee.jade.api.config.IWailaConfig.DisplayMode;
-import snownee.jade.api.config.IWailaConfig.Overlay;
 import snownee.jade.api.config.IWailaConfig.TTSMode;
-import snownee.jade.api.theme.IThemeHelper;
-import snownee.jade.api.theme.Theme;
-import snownee.jade.api.ui.BoxElement;
-import snownee.jade.api.ui.ColorPalette;
 import snownee.jade.api.ui.JadeUI;
-import snownee.jade.api.ui.ScreenDirection;
-import snownee.jade.api.ui.TooltipAnimation;
 import snownee.jade.compat.RecipeLookupPlugin;
 import snownee.jade.compat.RecipeLookupResult;
 import snownee.jade.gui.HomeConfigScreen;
 import snownee.jade.impl.WailaClientRegistration;
 import snownee.jade.impl.theme.ThemeHelper;
 import snownee.jade.key_extension.KeyMappingEx;
-import snownee.jade.overlay.DisplayHelper;
 import snownee.jade.overlay.WailaTickHandler;
 import snownee.jade.util.ClientProxy;
 import snownee.jade.util.CommonProxy;
@@ -87,9 +76,6 @@ public final class JadeClient {
 	public static float renderDistanceStart;
 	public static float renderDistanceEnd;
 	private static boolean translationChecked;
-	private static float savedProgress;
-	private static float progressAlpha;
-	private static boolean canHarvest;
 	private static long inPowderSnowTime;
 
 	public static void init() {
@@ -331,61 +317,6 @@ public final class JadeClient {
 			return null;
 		}
 		return accessor;
-	}
-
-	public static void drawBreakingProgress(
-			BoxElement root,
-			TooltipAnimation animation,
-			GuiGraphicsExtractor graphics,
-			Accessor<?> accessor) {
-		if (!IWailaConfig.get().plugin().get(JadeIds.MC_BREAKING_PROGRESS)) {
-			progressAlpha = 0;
-			return;
-		}
-		if (!Float.isNaN(root.getBoxProgress())) {
-			progressAlpha = 0;
-			return;
-		}
-		Minecraft mc = Minecraft.getInstance();
-		MultiPlayerGameMode playerController = mc.gameMode;
-		if (playerController == null || mc.level == null || mc.player == null) {
-			return;
-		}
-		BlockPos pos = playerController.destroyBlockPos;
-		BlockState state = mc.level.getBlockState(pos);
-		if (playerController.isDestroying()) {
-			canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
-		} else if (progressAlpha == 0) {
-			return;
-		}
-		Theme theme = IThemeHelper.get().theme();
-		ColorPalette colors = theme.tooltipStyle.boxProgressColors;
-		int color = canHarvest ? colors.title() : colors.failure();
-		float top = root.getY() + root.getHeight();
-		float width = root.getWidth();
-		progressAlpha += mc.getDeltaTracker().getGameTimeDeltaTicks() * (playerController.isDestroying() ? 0.1F : -0.1F);
-		if (playerController.isDestroying()) {
-			progressAlpha = Math.min(progressAlpha, 0.6F);
-			float progress = state.getDestroyProgress(mc.player, mc.player.level(), pos);
-			if (playerController.destroyProgress + progress >= 1) {
-				progressAlpha = savedProgress = 1;
-			} else {
-				progress = playerController.destroyProgress + mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progress;
-				savedProgress = Mth.clamp(progress, 0, 1);
-			}
-		} else {
-			progressAlpha = Math.max(progressAlpha, 0);
-		}
-		if (progressAlpha == 0) {
-			return;
-		}
-		color = Overlay.applyAlpha(color, progressAlpha);
-		float offset0 = theme.tooltipStyle.boxProgressOffset(ScreenDirection.UP);
-		float offset1 = theme.tooltipStyle.boxProgressOffset(ScreenDirection.RIGHT);
-		float offset2 = theme.tooltipStyle.boxProgressOffset(ScreenDirection.DOWN);
-		float offset3 = theme.tooltipStyle.boxProgressOffset(ScreenDirection.LEFT);
-		width += offset1 - offset3;
-		DisplayHelper.fill(graphics, offset3, top - 1 + offset0, offset3 + width * savedProgress, top + offset2, color);
 	}
 
 	public static MutableComponent format(String s, Object... objects) {

--- a/src/main/java/snownee/jade/addon/vanilla/BreakingProgressProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/BreakingProgressProvider.java
@@ -23,9 +23,7 @@ import snownee.jade.util.CommonProxy;
 public enum BreakingProgressProvider implements IBoxProgressProvider {
 	INSTANCE;
 
-	private float savedProgress;
 	private float progressAlpha;
-	private boolean canHarvest;
 
 	public static void register(IWailaClientRegistration registration) {
 		registration.addTooltipCollectedCallback((root, accessor) -> root.addProgressProvider(0, INSTANCE));
@@ -39,34 +37,22 @@ public enum BreakingProgressProvider implements IBoxProgressProvider {
 		}
 		Minecraft mc = Minecraft.getInstance();
 		MultiPlayerGameMode playerController = mc.gameMode;
-		if (playerController == null || mc.level == null || mc.player == null) {
+		if (playerController == null || mc.level == null || mc.player == null || !playerController.isDestroying()) {
+			progressAlpha = 0;
 			return null;
 		}
 		BlockPos pos = playerController.destroyBlockPos;
 		BlockState state = mc.level.getBlockState(pos);
-		if (playerController.isDestroying()) {
-			canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
-		} else if (progressAlpha == 0) {
-			return null;
-		}
-		float deltaTicks = mc.getDeltaTracker().getGameTimeDeltaTicks();
-		progressAlpha += deltaTicks * (playerController.isDestroying() ? 0.1F : -0.1F);
-		if (playerController.isDestroying()) {
-			progressAlpha = Math.min(progressAlpha, 0.6F);
-			float progress = state.getDestroyProgress(mc.player, mc.player.level(), pos);
-			if (playerController.destroyProgress + progress >= 1) {
-				progressAlpha = savedProgress = 1;
-			} else {
-				progress = playerController.destroyProgress + mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progress;
-				savedProgress = Mth.clamp(progress, 0, 1);
-			}
+		boolean canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
+		progressAlpha = Math.min(progressAlpha + mc.getDeltaTracker().getGameTimeDeltaTicks() * 0.1F, 0.6F);
+		float progress = state.getDestroyProgress(mc.player, mc.player.level(), pos);
+		if (playerController.destroyProgress + progress >= 1) {
+			progressAlpha = progress = 1;
 		} else {
-			progressAlpha = Math.max(progressAlpha, 0);
+			progress = playerController.destroyProgress + mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progress;
+			progress = Mth.clamp(progress, 0, 1);
 		}
-		if (progressAlpha == 0) {
-			return null;
-		}
-		return new BoxProgress(savedProgress, canHarvest ? MessageType.TITLE : MessageType.FAILURE, null, progressAlpha);
+		return new BoxProgress(progress, canHarvest ? MessageType.TITLE : MessageType.FAILURE, null, progressAlpha);
 	}
 
 }

--- a/src/main/java/snownee/jade/addon/vanilla/BreakingProgressProvider.java
+++ b/src/main/java/snownee/jade/addon/vanilla/BreakingProgressProvider.java
@@ -1,0 +1,72 @@
+package snownee.jade.addon.vanilla;
+
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.JadeIds;
+import snownee.jade.api.config.IWailaConfig;
+import snownee.jade.api.ui.BoxElement;
+import snownee.jade.api.ui.BoxProgress;
+import snownee.jade.api.ui.IBoxProgressProvider;
+import snownee.jade.api.ui.MessageType;
+import snownee.jade.util.CommonProxy;
+
+/**
+ * Drives the vanilla block-breaking progress bar rendered below the root tooltip.
+ */
+public enum BreakingProgressProvider implements IBoxProgressProvider {
+	INSTANCE;
+
+	private float savedProgress;
+	private float progressAlpha;
+	private boolean canHarvest;
+
+	public static void register(IWailaClientRegistration registration) {
+		registration.addTooltipCollectedCallback((root, accessor) -> root.addProgressProvider(0, INSTANCE));
+	}
+
+	@Override
+	public @Nullable BoxProgress getProgress(BoxElement box, Accessor<?> accessor, float partialTicks) {
+		if (!IWailaConfig.get().plugin().get(JadeIds.MC_BREAKING_PROGRESS)) {
+			progressAlpha = 0;
+			return null;
+		}
+		Minecraft mc = Minecraft.getInstance();
+		MultiPlayerGameMode playerController = mc.gameMode;
+		if (playerController == null || mc.level == null || mc.player == null) {
+			return null;
+		}
+		BlockPos pos = playerController.destroyBlockPos;
+		BlockState state = mc.level.getBlockState(pos);
+		if (playerController.isDestroying()) {
+			canHarvest = CommonProxy.isCorrectToolForDrops(state, mc.player, mc.level, pos);
+		} else if (progressAlpha == 0) {
+			return null;
+		}
+		float deltaTicks = mc.getDeltaTracker().getGameTimeDeltaTicks();
+		progressAlpha += deltaTicks * (playerController.isDestroying() ? 0.1F : -0.1F);
+		if (playerController.isDestroying()) {
+			progressAlpha = Math.min(progressAlpha, 0.6F);
+			float progress = state.getDestroyProgress(mc.player, mc.player.level(), pos);
+			if (playerController.destroyProgress + progress >= 1) {
+				progressAlpha = savedProgress = 1;
+			} else {
+				progress = playerController.destroyProgress + mc.getDeltaTracker().getGameTimeDeltaPartialTick(false) * progress;
+				savedProgress = Mth.clamp(progress, 0, 1);
+			}
+		} else {
+			progressAlpha = Math.max(progressAlpha, 0);
+		}
+		if (progressAlpha == 0) {
+			return null;
+		}
+		return new BoxProgress(savedProgress, canHarvest ? MessageType.TITLE : MessageType.FAILURE, null, progressAlpha);
+	}
+
+}

--- a/src/main/java/snownee/jade/addon/vanilla/VanillaPlugin.java
+++ b/src/main/java/snownee/jade/addon/vanilla/VanillaPlugin.java
@@ -227,7 +227,7 @@ public class VanillaPlugin implements IWailaPlugin {
 		registration.addRayTraceCallback(-10010, DatapackBlockManager::override);
 		registration.addRayTraceCallback(-1000, JadeClient::limitMobEffectFog);
 		registration.addRayTraceCallback(-10, JadeClient::builtInOverrides);
-		registration.addAfterRenderCallback(100, JadeClient::drawBreakingProgress);
+		BreakingProgressProvider.register(registration);
 
 		registration.markAsClientFeature(JadeIds.MC_EFFECTIVE_TOOL);
 		registration.markAsClientFeature(JadeIds.MC_HARVEST_TOOL_NEW_LINE);

--- a/src/main/java/snownee/jade/api/ui/BoxElement.java
+++ b/src/main/java/snownee/jade/api/ui/BoxElement.java
@@ -13,9 +13,20 @@ public abstract class BoxElement extends ResizeableElement implements StyledElem
 
 	public abstract void setBoxProgress(MessageType type, float progress);
 
-	public abstract float getBoxProgress();
-
 	public abstract void clearBoxProgress();
+
+	/**
+	 * Attaches a progress bar provider. Providers are queried every frame in ascending priority order; the first
+	 * non-null result wins.
+	 *
+	 * @param priority lower values are queried first
+	 * @param provider per-frame progress bar provider
+	 */
+	public abstract void addProgressProvider(int priority, IBoxProgressProvider provider);
+
+	public void addProgressProvider(IBoxProgressProvider provider) {
+		addProgressProvider(0, provider);
+	}
 
 	public abstract void setIcon(@Nullable Element icon);
 }

--- a/src/main/java/snownee/jade/api/ui/BoxProgress.java
+++ b/src/main/java/snownee/jade/api/ui/BoxProgress.java
@@ -1,0 +1,23 @@
+package snownee.jade.api.ui;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Desired state of a box progress bar for a single frame.
+ *
+ * @param progress normalized progress in the range {@code [0, 1]}; values outside the range are clamped when rendered
+ * @param type semantic color; resolved through the box style's {@code boxProgressColors} palette
+ * @param color optional opaque base color; when non-null it overrides the color derived from {@code type}
+ * @param alpha transparency multiplier in the range {@code [0, 1]}; applied to the resolved color by the box
+ */
+public record BoxProgress(float progress, MessageType type, @Nullable Integer color, float alpha) {
+
+	public BoxProgress(float progress, MessageType type) {
+		this(progress, type, null, 1);
+	}
+
+	public BoxProgress(float progress, MessageType type, float alpha) {
+		this(progress, type, null, alpha);
+	}
+
+}

--- a/src/main/java/snownee/jade/api/ui/IBoxProgressProvider.java
+++ b/src/main/java/snownee/jade/api/ui/IBoxProgressProvider.java
@@ -1,0 +1,28 @@
+package snownee.jade.api.ui;
+
+import org.jspecify.annotations.Nullable;
+
+import snownee.jade.api.Accessor;
+
+/**
+ * Provides the per-frame state of a {@link BoxElement}'s progress bar.
+ * <p>
+ * Providers attached to a box are queried every render frame in ascending priority order; the first non-null result is
+ * rendered for that frame. Returning {@code null} lets lower-priority providers or the box's static progress
+ * ({@link BoxElement#setBoxProgress}) take over. When no source returns a value, the box fades the bar out.
+ */
+@FunctionalInterface
+public interface IBoxProgressProvider {
+
+	/**
+	 * Returns the progress bar state for the current frame.
+	 *
+	 * @param box the box this provider is attached to
+	 * @param accessor the target currently displayed by Jade
+	 * @param partialTicks partial tick, for interpolating progress values
+	 * @return the desired progress bar state, or {@code null} when this provider is not active
+	 */
+	@Nullable
+	BoxProgress getProgress(BoxElement box, Accessor<?> accessor, float partialTicks);
+
+}

--- a/src/main/java/snownee/jade/impl/ui/BoxElementImpl.java
+++ b/src/main/java/snownee/jade/impl/ui/BoxElementImpl.java
@@ -24,7 +24,9 @@ import net.minecraft.client.gui.layouts.Layout;
 import net.minecraft.client.gui.layouts.LayoutElement;
 import net.minecraft.client.gui.layouts.LayoutSettings;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
+import snownee.jade.JadeClient;
 import snownee.jade.JadeInternals;
 import snownee.jade.api.Accessor;
 import snownee.jade.api.JadeIds;
@@ -49,6 +51,8 @@ import snownee.jade.gui.PreviewOptionsScreen;
 import snownee.jade.gui.ResizeableLayout;
 import snownee.jade.impl.Tooltip;
 import snownee.jade.overlay.DisplayHelper;
+import snownee.jade.track.BoxProgressFadeTrackInfo;
+import snownee.jade.track.ProgressTracker;
 import snownee.jade.util.ClientProxy;
 import snownee.jade.util.ToFloatFunction;
 import snownee.jade.util.WailaExceptionHandler;
@@ -66,6 +70,7 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 	private @Nullable BoxProgress pendingProgress;
 	private @Nullable BoxProgress fadeProgress;
 	private float fadeAlpha;
+	private @Nullable BoxProgressFadeTrackInfo fadeTrack;
 
 	public BoxElementImpl(Tooltip tooltip, BoxStyle style) {
 		this.tooltip = Objects.requireNonNull(tooltip);
@@ -237,7 +242,7 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 
 	@Override
 	public void clearBoxProgress() {
-		providers.removeIf(entry -> entry.priority() == STATIC_PROGRESS_PRIORITY);
+		providers.removeIf(entry -> entry.provider() instanceof StaticBoxProgressProvider);
 	}
 
 	@Override
@@ -269,23 +274,64 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 			fadeProgress = current;
 			fadeAlpha = current.alpha();
 			pendingProgress = current;
-		} else if (fadeProgress != null) {
-			fadeAlpha -= Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaTicks() * 0.1F;
-			if (fadeAlpha <= 0) {
-				fadeAlpha = 0;
-				fadeProgress = null;
-				pendingProgress = null;
-			} else {
-				pendingProgress = new BoxProgress(fadeProgress.progress(), fadeProgress.type(), fadeProgress.color(), fadeAlpha);
+			BoxProgressFadeTrackInfo track = getFadeTrack(true);
+			if (track != null) {
+				track.progress = fadeProgress;
+				track.alpha = fadeAlpha;
+				track.touch();
 			}
-		} else {
-			pendingProgress = null;
+			return;
 		}
+		BoxProgressFadeTrackInfo track = getFadeTrack(false);
+		if (track != null && fadeProgress == null) {
+			fadeProgress = track.progress;
+			fadeAlpha = track.alpha;
+		}
+		if (fadeProgress == null) {
+			pendingProgress = null;
+			return;
+		}
+		fadeAlpha -= Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaTicks() * 0.1F;
+		if (fadeAlpha <= 0) {
+			fadeAlpha = 0;
+			fadeProgress = null;
+			pendingProgress = null;
+		} else {
+			pendingProgress = new BoxProgress(fadeProgress.progress(), fadeProgress.type(), fadeProgress.color(), fadeAlpha);
+		}
+		if (track != null) {
+			track.progress = fadeProgress;
+			track.alpha = fadeAlpha;
+			if (fadeProgress != null) {
+				track.touch();
+			}
+		}
+	}
+
+	private @Nullable BoxProgressFadeTrackInfo getFadeTrack(boolean create) {
+		if (fadeTrack != null) {
+			return fadeTrack;
+		}
+		Identifier tag = getTag();
+		if (tag == null) {
+			return null;
+		}
+		ProgressTracker tracker = JadeClient.tickHandler().progressTracker;
+		fadeTrack = tracker.get(tag, BoxProgressFadeTrackInfo.class);
+		if (fadeTrack == null && create) {
+			fadeTrack = tracker.getOrCreate(tag, BoxProgressFadeTrackInfo.class, BoxProgressFadeTrackInfo::new);
+		}
+		return fadeTrack;
 	}
 
 	private void drawBoxProgressBar(GuiGraphicsExtractor graphics, BoxProgress progress) {
 		int baseColor = progress.color() != null ? progress.color() : style.boxProgressColors.get(progress.type());
-		int color = Overlay.applyAlpha(baseColor, progress.alpha());
+		float boxAlpha = IDisplayHelper.get().backgroundOpacity();
+		if (JadeIds.ROOT.equals(getTag())) {
+			boxAlpha *= IWailaConfig.get().overlay().getAlpha();
+		}
+		int color = Overlay.applyAlpha(baseColor, progress.alpha() * boxAlpha);
+		float x = getX();
 		float top = getY() + getHeight();
 		float width = getWidth();
 		float offset0 = style.boxProgressOffset(ScreenDirection.UP);
@@ -295,9 +341,9 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 		width += offset1 - offset3;
 		DisplayHelper.fill(
 				graphics,
-				offset3,
+				x + offset3,
 				top - 1 + offset0,
-				offset3 + width * Mth.clamp(progress.progress(), 0, 1),
+				x + offset3 + width * Mth.clamp(progress.progress(), 0, 1),
 				top + offset2,
 				color);
 	}
@@ -364,7 +410,8 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 			long deltaTime = System.currentTimeMillis() - animation.startTime;
 			long durationMillis = duration.toMillis();
 			float progress = (float) deltaTime / durationMillis;
-			animation.alpha = Mth.clamp(progress, 0.55F, animation.showHideAlpha);
+			//noinspection MathClampMigration
+			animation.alpha = Math.min(animation.showHideAlpha, Math.max(progress, 0.55F));
 			chase(animation, Rect2f::getX, src::setX, progress);
 			chase(animation, Rect2f::getY, src::setY, progress);
 			chase(

--- a/src/main/java/snownee/jade/impl/ui/BoxElementImpl.java
+++ b/src/main/java/snownee/jade/impl/ui/BoxElementImpl.java
@@ -1,6 +1,8 @@
 package snownee.jade.impl.ui;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -22,13 +24,18 @@ import net.minecraft.client.gui.layouts.Layout;
 import net.minecraft.client.gui.layouts.LayoutElement;
 import net.minecraft.client.gui.layouts.LayoutSettings;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import snownee.jade.JadeInternals;
+import snownee.jade.api.Accessor;
 import snownee.jade.api.JadeIds;
 import snownee.jade.api.config.IWailaConfig;
+import snownee.jade.api.config.IWailaConfig.Overlay;
 import snownee.jade.api.theme.IThemeHelper;
 import snownee.jade.api.ui.BoxElement;
+import snownee.jade.api.ui.BoxProgress;
 import snownee.jade.api.ui.BoxStyle;
 import snownee.jade.api.ui.Element;
+import snownee.jade.api.ui.IBoxProgressProvider;
 import snownee.jade.api.ui.IDisplayHelper;
 import snownee.jade.api.ui.JadeUI;
 import snownee.jade.api.ui.MessageType;
@@ -41,7 +48,7 @@ import snownee.jade.gui.LayoutWithPadding;
 import snownee.jade.gui.PreviewOptionsScreen;
 import snownee.jade.gui.ResizeableLayout;
 import snownee.jade.impl.Tooltip;
-import snownee.jade.track.ProgressTrackInfo;
+import snownee.jade.overlay.DisplayHelper;
 import snownee.jade.util.ClientProxy;
 import snownee.jade.util.ToFloatFunction;
 import snownee.jade.util.WailaExceptionHandler;
@@ -54,9 +61,11 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 	private @Nullable List<AbstractWidget> widgets;
 	private @Nullable List<GuiEventListener> eventListeners;
 	private @Nullable Element icon;
-	private float boxProgress;
-	private @Nullable MessageType boxProgressType;
-	private @Nullable ProgressTrackInfo track;
+	private static final int STATIC_PROGRESS_PRIORITY = Integer.MAX_VALUE;
+	private final List<PrioritizedProvider> providers = new ArrayList<>();
+	private @Nullable BoxProgress pendingProgress;
+	private @Nullable BoxProgress fadeProgress;
+	private float fadeAlpha;
 
 	public BoxElementImpl(Tooltip tooltip, BoxStyle style) {
 		this.tooltip = Objects.requireNonNull(tooltip);
@@ -189,6 +198,10 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 		}
 		graphics.disableScissor();
 
+		if (pendingProgress != null) {
+			drawBoxProgressBar(graphics, pendingProgress);
+		}
+
 		if (root && tooltip.sneakyDetails) {
 			IThemeHelper.get().theme().sneakyDetails.render(graphics, partialTicks, this);
 		}
@@ -210,115 +223,6 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 				});
 	}
 
-	//	@Override
-//	public void render(GuiGraphicsExtractor guiGraphics, final float x, final float y, final float maxX, final float maxY) {
-//		if (tooltip.isEmpty()) {
-//			return;
-//		}
-//		guiGraphics.pose().pushMatrix();
-//		guiGraphics.pose().translate(x, y);
-//
-//		// render background
-//		float alpha = IDisplayHelper.get().opacity();
-//		if (JadeIds.ROOT.equals(getTag())) {
-//			alpha *= IWailaConfig.get().overlay().getAlpha();
-//		}
-//		if (alpha > 0) {
-//			style.render(guiGraphics, this, 0, 0, maxX - x, maxY - y, alpha);
-//		}
-//
-//		int borderWidth = style.borderWidth();
-//		// render box progress
-//		if (boxProgressType != null) {
-//			float left = style.boxProgressOffset(ScreenDirection.LEFT) + borderWidth;
-//			float width = maxX - x - left;
-//			float top = maxY - y - 1 + style.boxProgressOffset(ScreenDirection.UP) + borderWidth;
-//			float height = 1 + style.boxProgressOffset(ScreenDirection.DOWN);
-//			float progress = boxProgress;
-//			if (track == null && tag != null) {
-//				track = WailaTickHandler.instance().progressTracker.getOrCreate(
-//						tag, ProgressTrackInfo.class, () -> {
-//							return new ProgressTrackInfo(false, boxProgress, 0);
-//						});
-//			}
-//			if (track != null) {
-//				track.setProgress(progress);
-//				track.update(Minecraft.getInstance().getDeltaTracker().getRealtimeDeltaTicks());
-//				progress = track.getSmoothProgress();
-//			}
-//			((DisplayHelper) IDisplayHelper.get()).drawGradientProgress(
-//					guiGraphics,
-//					left,
-//					top,
-//					width,
-//					height,
-//					progress,
-//					style.boxProgressColors.get(boxProgressType));
-//		}
-//
-//		float contentLeft = padding(ScreenDirection.LEFT) + borderWidth;
-//		float contentTop = padding(ScreenDirection.UP) + borderWidth;
-//
-//		// render icon
-//		if (icon != null) {
-//			Vec2 iconSize = icon.getCachedSize();
-//			Vec2 offset = icon.getTranslation();
-//			float offsetY = offset.y;
-//			float min = contentTop + padding(ScreenDirection.DOWN) + iconSize.y;
-//			IWailaConfig.IconMode iconMode = IWailaConfig.get().overlay().getIconMode();
-//			if (iconMode == IWailaConfig.IconMode.TOP && min < getCachedSize().y) {
-//				offsetY += contentTop;
-//			} else {
-//				offsetY += (size.y - iconSize.y) / 2;
-//			}
-//			float offsetX = contentLeft + offset.x;
-//			icon.render(guiGraphics, offsetX, offsetY, offsetX + iconSize.x, offsetY + iconSize.y);
-//			contentLeft += iconSize.x + 3;
-//		}
-//
-//		// render elements
-//		{
-//			boolean fancy = Minecraft.getInstance().options.graphicsMode().get() != GraphicsStatus.FAST;
-//			if (fancy) {
-//				guiGraphics.enableScissor(0, 0, (int) (maxX - x), (int) (maxY - y));
-//			}
-//			float lineTop = contentTop;
-//			int lineCount = tooltip.lines.size();
-//			Tooltip.Line line = tooltip.lines.getFirst();
-//			for (int i = 0; i < lineCount; i++) {
-//				Vec2 lineSize = line.size();
-//				line.render(guiGraphics, contentLeft, lineTop, maxX - x - padding(ScreenDirection.RIGHT), lineTop + lineSize.y);
-//				if (i < lineCount - 1) {
-//					int marginBottom = line.marginBottom;
-//					line = tooltip.lines.get(i + 1);
-//					lineTop += lineSize.y + calculateMargin(marginBottom, line.marginTop);
-//				}
-//			}
-//			if (fancy) {
-//				guiGraphics.disableScissor();
-//			}
-//		}
-//
-//		// render down arrow
-//		if (tooltip.sneakyDetails) {
-//			float arrowTop = (OverlayRenderer.ticks / 5) % 8 - 2;
-//			if (arrowTop <= 4) {
-//				alpha = 1 - Math.abs(arrowTop) / 2;
-//				if (alpha > 0.016) {
-//					guiGraphics.pose().pushMatrix();
-//					arrowTop += size.y - 6;
-//					float arrowLeft = contentLeft + (contentSize.x - DisplayHelper.font().width("▾") + 1) / 2f;
-//					guiGraphics.pose().translate(arrowLeft, arrowTop);
-//					int color = Overlay.applyAlpha(IThemeHelper.get().theme().text.colors().info(), alpha);
-//					DisplayHelper.INSTANCE.drawText(guiGraphics, "▾", 0, 0, color);
-//					guiGraphics.pose().popMatrix();
-//				}
-//			}
-//		}
-//
-//		guiGraphics.pose().popMatrix();
-//	}
-
 	@Override
 	public Tooltip getTooltip() {
 		return tooltip;
@@ -326,19 +230,79 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 
 	@Override
 	public void setBoxProgress(MessageType type, float progress) {
-		boxProgress = progress;
-		boxProgressType = type;
-	}
-
-	@Override
-	public float getBoxProgress() {
-		return boxProgressType == null ? Float.NaN : boxProgress;
+		providers.removeIf(entry -> entry.priority() == STATIC_PROGRESS_PRIORITY);
+		providers.add(new PrioritizedProvider(STATIC_PROGRESS_PRIORITY, new StaticBoxProgressProvider(progress, type)));
+		providers.sort(Comparator.comparingInt(PrioritizedProvider::priority));
 	}
 
 	@Override
 	public void clearBoxProgress() {
-		boxProgress = 0;
-		boxProgressType = null;
+		providers.removeIf(entry -> entry.priority() == STATIC_PROGRESS_PRIORITY);
+	}
+
+	@Override
+	public void addProgressProvider(int priority, IBoxProgressProvider provider) {
+		Objects.requireNonNull(provider);
+		providers.add(new PrioritizedProvider(priority, provider));
+		providers.sort(Comparator.comparingInt(PrioritizedProvider::priority));
+	}
+
+	public void beforeRender(Accessor<?> accessor, float partialTicks) {
+		computeBoxProgress(accessor, partialTicks);
+		for (Renderable renderable : renderables) {
+			if (renderable instanceof BoxElementImpl box) {
+				box.beforeRender(accessor, partialTicks);
+			}
+		}
+	}
+
+	private void computeBoxProgress(Accessor<?> accessor, float partialTicks) {
+		BoxProgress current = null;
+		for (PrioritizedProvider entry : providers) {
+			BoxProgress progress = entry.provider().getProgress(this, accessor, partialTicks);
+			if (progress != null) {
+				current = progress;
+				break;
+			}
+		}
+		if (current != null) {
+			fadeProgress = current;
+			fadeAlpha = current.alpha();
+			pendingProgress = current;
+		} else if (fadeProgress != null) {
+			fadeAlpha -= Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaTicks() * 0.1F;
+			if (fadeAlpha <= 0) {
+				fadeAlpha = 0;
+				fadeProgress = null;
+				pendingProgress = null;
+			} else {
+				pendingProgress = new BoxProgress(fadeProgress.progress(), fadeProgress.type(), fadeProgress.color(), fadeAlpha);
+			}
+		} else {
+			pendingProgress = null;
+		}
+	}
+
+	private void drawBoxProgressBar(GuiGraphicsExtractor graphics, BoxProgress progress) {
+		int baseColor = progress.color() != null ? progress.color() : style.boxProgressColors.get(progress.type());
+		int color = Overlay.applyAlpha(baseColor, progress.alpha());
+		float top = getY() + getHeight();
+		float width = getWidth();
+		float offset0 = style.boxProgressOffset(ScreenDirection.UP);
+		float offset1 = style.boxProgressOffset(ScreenDirection.RIGHT);
+		float offset2 = style.boxProgressOffset(ScreenDirection.DOWN);
+		float offset3 = style.boxProgressOffset(ScreenDirection.LEFT);
+		width += offset1 - offset3;
+		DisplayHelper.fill(
+				graphics,
+				offset3,
+				top - 1 + offset0,
+				offset3 + width * Mth.clamp(progress.progress(), 0, 1),
+				top + offset2,
+				color);
+	}
+
+	private record PrioritizedProvider(int priority, IBoxProgressProvider provider) {
 	}
 
 	@Override
@@ -400,7 +364,7 @@ public class BoxElementImpl extends BoxElement implements ContainerEventHandler 
 			long deltaTime = System.currentTimeMillis() - animation.startTime;
 			long durationMillis = duration.toMillis();
 			float progress = (float) deltaTime / durationMillis;
-			animation.alpha = Math.min(animation.showHideAlpha, Math.max(progress, 0.55F));
+			animation.alpha = Mth.clamp(progress, 0.55F, animation.showHideAlpha);
 			chase(animation, Rect2f::getX, src::setX, progress);
 			chase(animation, Rect2f::getY, src::setY, progress);
 			chase(

--- a/src/main/java/snownee/jade/impl/ui/StaticBoxProgressProvider.java
+++ b/src/main/java/snownee/jade/impl/ui/StaticBoxProgressProvider.java
@@ -1,0 +1,48 @@
+package snownee.jade.impl.ui;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.Mth;
+import snownee.jade.JadeClient;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.ui.BoxElement;
+import snownee.jade.api.ui.BoxProgress;
+import snownee.jade.api.ui.IBoxProgressProvider;
+import snownee.jade.api.ui.MessageType;
+import snownee.jade.api.view.ProgressView;
+import snownee.jade.track.ProgressTrackInfo;
+
+/**
+ * Static progress source that smooths its value through a persistent {@link ProgressTrackInfo} keyed by the box tag.
+ */
+class StaticBoxProgressProvider implements IBoxProgressProvider {
+	private final float progress;
+	private final MessageType type;
+	private @Nullable ProgressTrackInfo track;
+
+	StaticBoxProgressProvider(float progress, MessageType type) {
+		this.progress = progress;
+		this.type = type;
+	}
+
+	@Override
+	public BoxProgress getProgress(BoxElement box, Accessor<?> accessor, float partialTicks) {
+		Identifier tag = box.getTag();
+		if (tag == null) {
+			return new BoxProgress(progress, type);
+		}
+		List<ProgressView.Part> parts = List.of(ProgressView.Part.of(0, Mth.clamp(progress, 0, 1)));
+		if (track == null) {
+			track = JadeClient.tickHandler().progressTracker.getOrCreate(
+					tag, ProgressTrackInfo.class, () -> new ProgressTrackInfo(parts, false, box.getWidth()));
+		}
+		track.setProgress(parts);
+		track.update(Minecraft.getInstance().getDeltaTracker().getRealtimeDeltaTicks());
+		return new BoxProgress(track.getSmoothProgress(parts.getFirst()), type);
+	}
+
+}

--- a/src/main/java/snownee/jade/overlay/OverlayRenderer.java
+++ b/src/main/java/snownee/jade/overlay/OverlayRenderer.java
@@ -192,6 +192,8 @@ public class OverlayRenderer {
 					return;
 				}
 			}
+
+			root.beforeRender(tickHandler.state.accessor(), partialTicks);
 		}
 
 		boolean renderDebug = IWailaConfig.get().general().isDebug() && JadeUI.hasControlDown();

--- a/src/main/java/snownee/jade/track/BoxProgressFadeTrackInfo.java
+++ b/src/main/java/snownee/jade/track/BoxProgressFadeTrackInfo.java
@@ -1,0 +1,32 @@
+package snownee.jade.track;
+
+import org.jspecify.annotations.Nullable;
+
+import snownee.jade.api.ui.BoxProgress;
+
+/**
+ * Persistent box progress bar fade state, keyed by box tag in the {@link ProgressTracker}.
+ */
+public class BoxProgressFadeTrackInfo extends TrackInfo {
+	public @Nullable BoxProgress progress;
+	public float alpha;
+
+	public BoxProgressFadeTrackInfo() {
+		persistent = true;
+	}
+
+	/**
+	 * Marks this track as in use for the current tick so the tracker keeps it alive.
+	 */
+	public void touch() {
+		updatedThisTick = true;
+	}
+
+	@Override
+	public void update(float pTicks) {
+	}
+
+	@Override
+	public void tick() {
+	}
+}

--- a/src/main/java/snownee/jade/track/ProgressTracker.java
+++ b/src/main/java/snownee/jade/track/ProgressTracker.java
@@ -3,6 +3,8 @@ package snownee.jade.track;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -29,6 +31,16 @@ public class ProgressTracker {
 		return info;
 	}
 
+	@Nullable
+	public <T extends TrackInfo> T get(Identifier tag, Class<T> type) {
+		for (TrackInfo o : map.get(tag)) {
+			if (type.isInstance(o)) {
+				return type.cast(o);
+			}
+		}
+		return null;
+	}
+
 	public void tick() {
 		if (map.isEmpty()) {
 			return;
@@ -45,7 +57,7 @@ public class ProgressTracker {
 	}
 
 	public void clear() {
-		map.clear();
+		map.values().removeIf(info -> !info.persistent);
 	}
 
 }

--- a/src/main/java/snownee/jade/track/TrackInfo.java
+++ b/src/main/java/snownee/jade/track/TrackInfo.java
@@ -3,6 +3,7 @@ package snownee.jade.track;
 public abstract class TrackInfo {
 	protected boolean alive = true;
 	protected boolean updatedThisTick;
+	protected boolean persistent;
 
 	public abstract void update(float pTicks);
 


### PR DESCRIPTION
Replaces the breaking-progress provider API proposed in #779 with a generic, element-attached box progress provider.

## What this PR adds

- `IBoxProgressProvider` (`@FunctionalInterface`): returns `@Nullable BoxProgress` each render frame; `null` means inactive.
- `BoxProgress(float progress, MessageType type, @Nullable Integer color, float alpha)`: full per-frame control of progress, theme-aware color (or raw override) and transparency.
- `BoxElement.addProgressProvider(int priority, IBoxProgressProvider)`: attach providers to any box; first non-null result wins.
- The box renders its own bottom progress bar (the previously disabled box-progress rendering is restored). When no provider is active the bar fades out; fade state is persisted in the tag-keyed `ProgressTracker` (`BoxProgressFadeTrackInfo`), so it survives the per-tick tooltip rebuild for root and nested boxes alike.
- `setBoxProgress` is unified as a lowest-priority constant provider; static progress is smoothed through the existing `ProgressTrackInfo` system (`StaticBoxProgressProvider`).
- Vanilla breaking progress is now `addon.vanilla.BreakingProgressProvider`, attached to the root box as a priority-0 provider that third-party providers can override.

## Relationship to #779

#779 introduced a breaking-specific global registry (`IBreakingProgressProvider` + `registerBreakingProgressProvider` on `IWailaClientRegistration`) queried with an `Accessor`. This PR supersedes that design:

| #779 | This PR |
| --- | --- |
| Breaking-specific interface | Generic `IBoxProgressProvider` for any box |
| Global registry on `IWailaClientRegistration` | Attached to the `BoxElement` via the existing `tooltipCollectedCallback` |
| `BreakingProgress(progress, canHarvest)` (color by boolean) | `BoxProgress(progress, type, color, alpha)` (direct color/alpha control) |
| Color derived internally | Color resolved by the box style palette, with raw override |
| — | Unified with existing `setBoxProgress`; progress bar rendered by the box |

`JadeClient.drawBreakingProgress` (an after-render callback) is removed.

## Breaking API changes

- `BoxElement.getBoxProgress()` removed (NaN convention dropped).
- `clearBoxProgress()` now removes the static provider installed by `setBoxProgress` (by type) instead of all providers at the reserved static priority.